### PR TITLE
fix: use brew command directly to check the syntax in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,9 @@ jobs:
 
       - run: brew test-bot --only-setup
 
-      - run: brew test-bot --only-tap-syntax
+      - run: brew style fluxninja/aperture
+
+      - run: brew readall --aliases fluxninja/aperture
 
       - run: brew test-bot --only-formulae
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Using the `brew test-bot --only-tap-syntax` was causing the `brew audit --tap=fluxninja/aperture` to fail in CI . As it is not required mentioned in the issue. So we can skip it. 
Now we are not using `brew test-bot ..` command to check the syntax .. and directly using the `brew audit..` and `brew style.. ` commands.

Closes https://github.com/fluxninja/aperture/issues/1627

cc @sbienkow-ninja 